### PR TITLE
added action to create accounts and website inbox with ready to use webtoken, added dev stack without nginx and with open chatwoot port for public

### DIFF
--- a/chatwoot.yaml
+++ b/chatwoot.yaml
@@ -18,8 +18,8 @@ common:
       image: chatwoot/chatwoot:latest
       environment:
         - NODE_ENV=production
+        - RAILS_ENV=production
         - DEFAULT_LOCALE=en
-        - <- `REDIS_URL=redis://${redis-host}:6379`
         - <- `SECRET_KEY_BASE=${secret-key-base}`
         - <- `REDIS_URL=redis://${redis-host}:6379`
         - <- `POSTGRES_HOST=${db-host}`
@@ -112,7 +112,7 @@ nginx:
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "Upgrade";
           }
-          
+
           location / {
             proxy_pass {{ v "proxy-pass-protocol" }}://{{ v "chatwoot-url" }}:{{ v "chatwoot-port" }};
           }
@@ -159,27 +159,88 @@ chatwoot:
     rails:
       entrypoint: <- `/bin/sh /init.sh`
       ports:
-        - 3000
-  depends:
-    defines: depends
-    wait-for:
-      runnables:
-        - chatwoot/postgres
-        - chatwoot/sidekiq
-        - chatwoot/redis
-      timeout: 60
+        - <- `${chatwoot-port}`
   files:
     defines: files
     init:
       path: /init.sh
       container: rails
       contents: | 
-        bundle exec rails db:chatwoot_prepare RAILS_ENV=production 
-        bundle exec rails s -p 3000 -b 0.0.0.0
+        bundle exec rails db:chatwoot_prepare
+        bundle exec rails s -p {{ v "chatwoot-port" }} -b 0.0.0.0
+    token-script:
+      container: rails
+      path: /tokenscript.sh
+      mode: 0770
+      contents: |
+        #!/usr/bin/env sh
+        TOKENFILE=/webtoken
+        USER=$1
+        PASSWORD=$2
+        APP_NAME=$3
+        if test -f "$TOKENFILE"; then
+          TOKEN=$(cat $TOKENFILE)
+        else
+          cd app
+          TOKEN=$(echo "PlatformApp.create(name: '$APP_NAME').access_token.token;
+          SuperAdmin.create!(email: '$USER', password: '$PASSWORD')
+          account = Account.create!(name: '$APP_NAME')
+          user = User.new(email: '$USER',
+                          password: '$PASSWORD',
+                          password_confirmation: '$PASSWORD',
+                          name: '$APP_NAME')
+          user.confirm(false)
+          user.save!
+
+          AccountUser.create!(account_id: account.id,
+                              user_id: user.id,
+                              role: AccountUser.roles['administrator']);
+
+          c = Channel::WebWidget.create!(account: account, website_url: 'test.com')
+
+          Inbox.create!(channel: c, account: account, name: '$APP_NAME')
+
+          File.open('/webtoken', 'w'){|file| file.write(c.website_token);};
+          ::Redis::Alfred.delete(::Redis::Alfred::CHATWOOT_INSTALLATION_ONBOARDING)
+          exit" | bundle exec rails c)
+          cd ..
+        fi
+        cat $TOKENFILE
+  actions:
+    defines: actions
+    get-token:
+      arguments:
+        user:
+          type: string
+          description: email for default user and superadmin
+          default: user@chatwoot.io
+        password:
+          type: string
+          description: password for default user and superadmin
+          default: Pass1234!
+        app-name:
+          type: string
+          description: app name which will be displayed in chatwoot
+          default: demo app
+      code: exec("rails", "/bin/sh", "/tokenscript.sh", $args["user"], $args["password"], $args["app-name"])
+
+dev-chatwoot:
+  defines: runnable
+  inherits: ./chatwoot
+  containers:
+    rails:
+      ports:
+        - <- `${chatwoot-port}:${chatwoot-port}`
 
 sidekiq:
   defines: runnable
   inherits: ./common
+  depends:
+    defines: depends
+    wait-for:
+        runnables:
+            - chatwoot/redis
+        timeout: 60
   containers:
     rails:
       bash: <- `bundle exec sidekiq -C /config/sidekiq.yml`
@@ -214,16 +275,7 @@ sidekiq:
         staging:
           :concurrency: 5
 
-stack:
-  defines: process-group
-  version: latest
-  runnable-list:
-    - /chatwoot/redis
-    - /chatwoot/postgres
-    - /chatwoot/sidekiq
-    - /chatwoot/chatwoot
-    - /chatwoot/nginx
-  variables:
+group-variables:
     defines: variables
     proxy-protocol: http
     chatwoot-port: 3000
@@ -279,3 +331,27 @@ stack:
       value: ""
     slack-client-secret:
       value: ""
+
+stack:
+  defines: process-group
+  version: latest
+  runnable-list:
+    - /chatwoot/redis
+    - /chatwoot/postgres
+    - /chatwoot/sidekiq
+    - /chatwoot/chatwoot
+    - /chatwoot/nginx
+  variables:
+    defines: variables
+    inherits: ./group-variables
+
+dev-stack:
+  defines: process-group
+  runnable-list:
+    - /chatwoot/redis
+    - /chatwoot/postgres
+    - /chatwoot/sidekiq
+    - /chatwoot/dev-chatwoot
+  variables:
+    defines: variables
+    inherits: ./group-variables


### PR DESCRIPTION
Hi,

This PR introduced 2 things:
- action to chatwoot runnable which can be used to onboard user automatically and generate webpage inbox. It can be run using either CLI:
```
monk do chatwoot/chatwoot/get-token user=example@monk.io password=Pass1234! app-name=demoapp
``` 
or called using monkscript for example when resolving variable:
```
      chatwoot-token:
        type: string
        env: REACT_APP_CHATWOOT_TOKEN
        value: <- act("chatwoot/dev-chatwoot/get-token", "user", $chatwoot-user, "password", $chatwoot-password, "app-name", $chatwoot-app-name)
```

- also introduced is dev stack without nginx and chatwoot port open to public for those users which just want to test it easily.